### PR TITLE
Fisher compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Afterwards, you should have a folder `.vscode-server` in your home directory.
 
 ## Usage
 
-Set up an alias for `code`, pointing to `code_connect.py` by placing the following line in your shell's rcfile. That's it, you can now use `code` the usual way.
+Set up an alias for `code`, pointing to [`code_connect.py`](./functions/code_connect.py) by placing the following line in your shell's rcfile. That's it, you can now use `code` the usual way.
 
 ```bash
 alias code="/path/to/code_connect.py"
@@ -37,12 +37,12 @@ alias code="/path/to/code_connect.py"
 
 - For **bash**, use `~/.bashrc`.
 
-- For **fish**, use `~/.config/fish/config.fish`.
+- For [**fish**](https://fishshell.com/), use `~/.config/fish/config.fish`.
 
-  Fish users can alternatively install a [plugin](https://github.com/chvolkmann/code-connect-fish-plugin) with the [fisher plugin manager](https://github.com/jorgebucaran/fisher).
+  Fish users can use [fisher](https://github.com/jorgebucaran/fisher) for an automatic install
 
   ```bash
-  fisher install chvolkmann/code-connect-fish-plugin
+  fisher install chvolkmann/code-connect
   ```
 
 ## Changelog

--- a/functions/code.fish
+++ b/functions/code.fish
@@ -1,0 +1,10 @@
+#!/usr/bin/fish
+
+# https://github.com/chvolkmann/code-connect
+
+# absolute path to code_connect.py
+set _CODE_CONNECT_PY (dirname (realpath (status --current-filename)))/code_connect.py
+
+function code --description 'Run Visual Studio Code through code-connect'
+    $_CODE_CONNECT_PY $argv
+end

--- a/functions/code_connect.py
+++ b/functions/code_connect.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# based on https://stackoverflow.com/a/60949722
+# https://github.com/chvolkmann/code-connect
 
 import time
 import subprocess as sp


### PR DESCRIPTION
> Apart from this repo, there's also [code-connect-fish-plugin](https://github.com/chvolkmann/code-connect-fish-plugin) which is used for quick installation through
> 
>     fisher install chvolkmann/code-connect-fish-plugin
> 
> I believe fisher supports repos that do not adhere to its [expected structure](https://github.com/jorgebucaran/fisher#creating-a-plugin). It's preferable to put the fisher integration into this repo as well, so you can simply run
> 
>     fisher install chvolkmann/code-connect
> 
> instead. Also maintaining two repos is annoying.

Resolves #3 

This puts `code_connect.py` into the `functions` folder, so fisher can discover it automatically. Along with it, `code.fish` sets up the alias to `code_connect.py`