### PR TITLE
feat: add zsh plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,36 @@ curl -sS https://raw.githubusercontent.com/chvolkmann/code-connect/main/bash/uni
 
 Deletes the aliases from `~/.bashrc` and removes the folder `~/.code-connect`
 
+### Zsh
+
+#### Installing
+
+With [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh)
+
+1. Clones the repository into `$ZSH_CUSTOM/plugins` (by default `~/.oh-my-zsh/custom/plugins`)
+
+```zsh
+git clone https://github.com/chvolkmann/code-connect $ZSH_CUSTOM/plugins/code-connect
+```
+
+2. Add `code-connect` to the plugins array in your `.zshrc` file
+
+```zsh
+plugins=(... code-connect)
+```
+
+#### Updating
+
+```zsh
+git -C $ZSH_CUSTOM/plugins/code-connect pull
+```
+
+#### Uninstalling
+
+```zsh
+rm -rf $ZSH_CUSTOM/plugins/code-connect
+```
+
 ## Usage
 
 Use `code` as you would normally!

--- a/code-connect.plugin.zsh
+++ b/code-connect.plugin.zsh
@@ -1,0 +1,7 @@
+# Add the binary directory to user's path
+PLUGIN_DIR="$(dirname $0)"
+export PATH="${PATH}:${PLUGIN_DIR}/bin"
+
+# update fpath, and then lazy autoload files in the directory as functions
+fpath=($PLUGIN_DIR/zsh_functions $fpath)
+autoload -U code code-connect

--- a/zsh_functions/code
+++ b/zsh_functions/code
@@ -1,0 +1,9 @@
+# The $commands arrays are described in the zsh/parameter module to access the internal hash tables.
+# $+param expands to 0 if param is unset, and 1 if it's set.
+if [[ ${+commands[code]} -eq 1 ]] ; then
+    # code is a command, use that binary instead of the code-connect
+    command code "$@"
+else
+    # code not locally installed, use code-connect
+    code_connect.py "$@"
+fi

--- a/zsh_functions/code-connect
+++ b/zsh_functions/code-connect
@@ -1,0 +1,1 @@
+code_connect.py "$@"


### PR DESCRIPTION
Thank you for maintaining this useful project. I created this PR to add a zsh plugin that may make it easier for zsh users to use this project.

The main ideas is to use the zsh [autoload](https://zsh.sourceforge.io/Doc/Release/Functions.html#Autoloading-Functions) builtin to define the `code` and `code-connect` functions.

I see that you add a unified install script in [#10](https://github.com/chvolkmann/code-connect/pull/10). However, a common way to install a zsh plugin is to `git clone` and `source` it in the `.zshrc` manually, or use a framework like oh-my-zsh and update the plugin list. Framework can also use `git pull` to upgrade the project automatically. So currently I directly added `bin/` to `$PATH` to make `code_connect.py` callable instead of telling user to use the script to install and upgrade manually.

Welcome your feedback and suggestions.
