### PR TITLE
Add SSH session check, for systems with code, but also remote code

### DIFF
--- a/bash/code.sh
+++ b/bash/code.sh
@@ -6,8 +6,8 @@
 #   alias code="/path/to/code.sh"
 
 local_code_executable="$(which code 2>/dev/null)"
-if test -n "$local_code_executable"; then
-    # code is in the PATH, use that binary instead of the code-connect
+if [ -n "$local_code_executable" ] && ! ( [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ] ); then
+    # code is in the PATH and we're not in an SSH session, use that binary instead of the code-connect
     $local_code_executable $@
 else
     # code not locally installed, use code-connect


### PR DESCRIPTION
I have a laptop that I connect to remotely sometimes, and so the `code` alias did not work properly due to the local install of vscode existing on that computer. This change adds a check to use the code_connect.py in the event that the connection is via SSH regardless of the existence of a remote installation of code, but works fine in non-remote terminal sessions.

Obviously if the users environment has erroneous SSH_CLIENT or SSH_TTY values set despite not using SSH, this will break, but I think that's their fault and not this script. 😉