### PR TITLE
Update to work with newer VSCode Server folder structure + dual installation fix

### DIFF
--- a/bash/code.sh
+++ b/bash/code.sh
@@ -6,8 +6,8 @@
 #   alias code="/path/to/code.sh"
 
 local_code_executable="$(which code 2>/dev/null)"
-if test -n "$local_code_executable"; then
-    # code is in the PATH, use that binary instead of the code-connect
+if [ -n "$local_code_executable" ] && ! ( [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ] ); then
+    # code is in the PATH and we're not in an SSH session, use that binary instead of the code-connect
     $local_code_executable $@
 else
     # code not locally installed, use code-connect

--- a/bin/code_connect.py
+++ b/bin/code_connect.py
@@ -39,9 +39,7 @@ def is_socket_open(path: Path) -> bool:
 
 def sort_by_access_timestamp(paths: Iterable[Path]) -> List[Tuple[float, Path]]:
     """ Returns a list of tuples (last_accessed_ts, path) sorted by the former. """
-    paths = [(p.stat().st_atime, p) for p in paths]
-    paths = sorted(paths, reverse=True)
-    return paths
+    return sorted([(p.stat().st_atime, p) for p in paths], reverse=True)
 
 
 def next_open_socket(socks: Sequence[Path]) -> Path:
@@ -68,17 +66,17 @@ def get_code_binary() -> Path:
 
     # Every entry in ~/.vscode-server/bin corresponds to a commit id
     # Pick the most recent one
-    code_repos = sort_by_access_timestamp(Path.home().glob(".vscode-server/bin/*"))
+    code_repos = sort_by_access_timestamp(Path.home().glob(".vscode-server/cli/servers/*"))
     if len(code_repos) == 0:
         fail(
             "No installation of VS Code Server detected!",
             "",
             "Please connect to this machine through a remote SSH session and try again.",
-            "Afterwards there should exist a folder under ~/.vscode-server",
+            "Afterwards there should exist a folder under ~/.vscode-server/cli/servers/",
         )
 
     _, code_repo = code_repos[0]
-    return code_repo / "bin" / "remote-cli" / "code"
+    return code_repo / "server" / "bin" / "remote-cli" / "code"
 
 
 def get_ipc_socket(max_idle_time: int = DEFAULT_MAX_IDLE_TIME) -> Path:


### PR DESCRIPTION
This PR fixes the detection to work with the newer VSCode Remote Server file structure. Not sure when it changed, but it works again with this.

I also included a fix I made for cases where the remote system might also have a local installation of VSCode, where code-connect might conflict.